### PR TITLE
PR: Adding checker for items.dat

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -43,6 +43,9 @@ int main()
     server->checksum = enet_crc32;
     enet_host_compress_with_range_coder(server);
     {
+        std::ifstream("items.dat", std::ios::binary);
+        if (!std::filesystem::exists("items.dat")) printf("items.dat not found\n");
+        
         const uintmax_t size = std::filesystem::file_size("items.dat");
 
         im_data.resize(im_data.size() + size + 1/*@todo*/); // @note state + items.dat


### PR DESCRIPTION
Adding items.dat checker because on windows ( builded using msvc ) it's not showd the error and just shows the infromation of the package, but on linux ( that i've test ), its shows if items.dat are not exist.