### PR TITLE
PR: Fix graceful shutdown on Windows and Linux

### DIFF
--- a/include/database/peer.cpp
+++ b/include/database/peer.cpp
@@ -224,15 +224,21 @@ std::vector<ENetPeer*> peers(const std::string &world, peer_condition condition,
 void safe_disconnect_peers(int code)
 {
     puts("killing gurotopia...");
+    if (!host)
+    {
+        puts("killed gurotopia safely!");
+        return;
+    }
+
     for (ENetPeer &p : std::span(host->peers, host->peerCount))
         if (p.state == ENET_PEER_STATE_CONNECTED)
             enet_peer_disconnect(&p, 0);
 
+    enet_host_flush(host);
+    enet_host_destroy(host);
+    host = nullptr;
     enet_deinitialize();
     puts("killed gurotopia safely!");
-#ifdef _WIN32 // @note linux handles this already
-    exit(code);
-#endif
 }
 
 state get_state(const std::vector<u_char> &&packet) 

--- a/main.cpp
+++ b/main.cpp
@@ -12,12 +12,19 @@
 #include <filesystem>
 #include <csignal>
 
+static volatile std::sig_atomic_t shutdown_requested{};
+
+static void request_shutdown(int)
+{
+    shutdown_requested = 1;
+}
+
 int main()
 {
     /* !! please press Ctrl + C when restarting or stopping server !! */
-    std::signal(SIGINT, safe_disconnect_peers);
+    std::signal(SIGINT, request_shutdown);
 #ifdef SIGHUP // @note unix
-    std::signal(SIGHUP,  safe_disconnect_peers); // @note PuTTY, SSH problems
+    std::signal(SIGHUP, request_shutdown); // @note PuTTY, SSH problems
 #endif
 
     /* libary version checker */
@@ -47,10 +54,11 @@ int main()
     check_for_holiday(); // @note check for any holidays using local time (your VPS or local time) - @todo thread loop so it can change the holiday without restarting
 
     ENetEvent event{};
-    while (true)
+    while (!shutdown_requested)
         while (enet_host_service(host, &event, 1000/*ms*/) > 0)
             if (const auto i = event_pool.find(event.type); i != event_pool.end())
                 i->second(event);
 
+    safe_disconnect_peers(0);
     return 0;
 }


### PR DESCRIPTION
Previously, `SIGINT` called `safe_disconnect_peers` directly.
On Linux, that function returned without exiting the process, so the server kept running and every extra `Ctrl+C` printed the shutdown logs again.
On Windows, shutdown relied on a platform-specific `exit()` path.

This change makes shutdown behavior consistent across platforms and avoids doing the full cleanup work directly inside the signal handler.

## Changes
- replace direct signal cleanup with a shutdown request flag
- stop the main ENet loop when shutdown is requested
- run peer disconnect and ENet cleanup once in normal program flow
- destroy the ENet host and clear the global host pointer during shutdown
- remove Windows-only forced exit logic from `safe_disconnect_peers`