### PR TITLE
PR: Add gazette dialog into shared helper and add `/news` command

### DIFF
--- a/include/action/enter_game.cpp
+++ b/include/action/enter_game.cpp
@@ -1,5 +1,6 @@
 #include "pch.hpp"
 #include "on/RequestWorldSelectMenu.hpp"
+#include "on/RequestGazette.hpp"
 #include "tools/string.hpp"
 #include "tools/create_dialog.hpp"
 #include "on/SetBux.hpp"
@@ -42,7 +43,6 @@ void action::enter_game(ENetEvent& event, const std::string& header)
 
     {
         std::tm time = localtime();
-        std::vector<std::string> month = { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
 
         packet::create(*event.peer, false, 0, {
             "OnTodaysDate",
@@ -53,45 +53,7 @@ void action::enter_game(ENetEvent& event, const std::string& header)
         }); 
 
         on::RequestWorldSelectMenu(event);
-
-        /* @todo move to a function and call in /news & here */
-        packet::create(*event.peer, false, 0, {
-            "OnDialogRequest",
-            ::create_dialog()
-                .set_default_color("`o")
-                .add_label_with_icon("big", "`wThe Gurotopia Gazette``", 5016)
-                .add_spacer("small")
-                .add_image_button("banner", holiday_banner(), "bannerlayout", "")
-                .add_spacer("small")
-                .add_textbox(std::format("`w{} {}{}: {}|", month[time.tm_mon], time.tm_mday,
-                    (time.tm_mday >= 11 && time.tm_mday <= 13) ? "th" :
-                    (time.tm_mday % 10 == 1) ? "st" :
-                    (time.tm_mday % 10 == 2) ? "nd" :
-                    (time.tm_mday % 10 == 3) ? "rd" : "th", holiday_greeting().first))
-                .add_spacer("small")
-                /* IOTM goes here. but it's P2W, so i will not add. */
-                .add_textbox("Love is popping, hearts are dropping, and we are officially in the `@Valentine's`` spirit! `@Valentine's Week`` has arrived, bringing sweet surprises, shiny rewards ready to steal your heart!")
-                .add_spacer("small")
-                .add_textbox("Taking center stage is the fabulous `9Golden Heart Crystal``, a true treasure of love that can be used to create dazzling gold items! Finding it won't be easy, but then again, true love never is! Keep your eyes peeled while breaking a `pHeartstone``, `8Golden Booty Chest``, `8Super Golden Booty Chest``, or taking a chance at the `#Well of Love``, you never know when luck strikes!")
-                .add_spacer("small")
-                .add_textbox("If your heart beats for competition, the `cEssence of Love Daily Challenge`` is calling your name! Show your dedication, place in the top 5, and you'll be rewarded with a `9Golden Heart Crystal`` as proof that love really does pay off!")
-                .add_spacer("small")
-                .add_textbox("Visit our Social Media pages for more Content!")
-                .add_spacer("small")
-                .add_image_button("gazette_DiscordServer", "interface/large/gazette/gazette_5columns_social_btn01.rttex", "7imageslayout", "https://discord.com/invite/zzWHgzaF7J")
-                .add_layout_spacer("7imageslayout")
-                .add_layout_spacer("7imageslayout")
-                .add_layout_spacer("7imageslayout")
-                .add_layout_spacer("7imageslayout")
-                .add_layout_spacer("7imageslayout")
-                .add_layout_spacer("7imageslayout")
-                .add_spacer("small")
-                .add_image_button("gazette_PrivacyPolicy", "interface/large/gazette/gazette_3columns_policy_btn02.rttex", "3imageslayout", "https://www.ubisoft.com/en-us/privacy-policy")
-                .add_image_button("gazette_GrowtopianCode", "interface/large/gazette/gazette_3columns_policy_btn01.rttex", "3imageslayout", "https://support.ubi.com/en-us/growtopia-faqs/the-growtopian-code/")
-                .add_image_button("gazette_TermsofUse", "interface/large/gazette/gazette_3columns_policy_btn03.rttex", "3imageslayout", "https://legal.ubi.com/termsofuse/")
-                .add_quick_exit().add_spacer("small")
-                .end_dialog("gazette", "", "OK").c_str()
-        });
+        on::RequestGazette(event);
     } // @note delete now, time
 
     send_data(*event.peer, compress_state(::state{

--- a/include/commands/__command.cpp
+++ b/include/commands/__command.cpp
@@ -8,6 +8,7 @@
 #include "sb.hpp"
 #include "who.hpp"
 #include "me.hpp"
+#include "news.hpp"
 #include "weather.hpp"
 #include "ghost.hpp"
 #include "ageworld.hpp"
@@ -16,7 +17,7 @@
 /* if you plan to use this outside of this file, please include in __command.hpp (^-^) - and just make it a void. */
 auto help_return = [](ENetEvent& event, const std::string_view text) 
 {
-    packet::action(*event.peer, "log", "msg|>> Commands: /find /warp {world} /edit {player} /punch {id} /skin {id} /sb {msg} /who /me {msg} /weather {id} /ghost /ageworld /wave /dance /love /sleep /facepalm /fp /smh /yes /no /omg /idk /shrug /furious /rolleyes /foldarms /stubborn /fold /dab /sassy /dance2 /march /grumpy /shy \0");
+    packet::action(*event.peer, "log", "msg|>> Commands: /find /warp {world} /edit {player} /punch {id} /skin {id} /sb {msg} /who /me {msg} /news /weather {id} /ghost /ageworld /wave /dance /love /sleep /facepalm /fp /smh /yes /no /omg /idk /shrug /furious /rolleyes /foldarms /stubborn /fold /dab /sassy /dance2 /march /grumpy /shy \0");
 };
 
 std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::string_view)>> cmd_pool
@@ -31,6 +32,7 @@ std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::s
     {"sb", &sb},
     {"who", &who},
     {"me", &me},
+    {"news", &news},
     {"weather", &weather},
     {"ghost", &ghost},
     {"ageworld", &ageworld},

--- a/include/commands/news.cpp
+++ b/include/commands/news.cpp
@@ -1,0 +1,9 @@
+#include "pch.hpp"
+#include "on/RequestGazette.hpp"
+
+#include "news.hpp"
+
+void news(ENetEvent& event, const std::string_view text)
+{
+    on::RequestGazette(event);
+}

--- a/include/commands/news.hpp
+++ b/include/commands/news.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+extern void news(ENetEvent& event, const std::string_view text);

--- a/include/on/RequestGazette.cpp
+++ b/include/on/RequestGazette.cpp
@@ -1,0 +1,51 @@
+#include "pch.hpp"
+#include "tools/create_dialog.hpp"
+#include "automate/holiday.hpp"
+
+#include "RequestGazette.hpp"
+
+void on::RequestGazette(ENetEvent& event)
+{
+    std::tm time = localtime();
+    std::vector<std::string> month = { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
+
+    std::string dialog = ::create_dialog()
+        .set_default_color("`o")
+        .add_label_with_icon("big", "`wThe Gurotopia Gazette``", 5016)
+        .add_spacer("small")
+        .add_image_button("banner", holiday_banner(), "bannerlayout", "")
+        .add_spacer("small")
+        .add_textbox(std::format("`w{} {}{}: {}|", month[time.tm_mon], time.tm_mday,
+            (time.tm_mday >= 11 && time.tm_mday <= 13) ? "th" :
+            (time.tm_mday % 10 == 1) ? "st" :
+            (time.tm_mday % 10 == 2) ? "nd" :
+            (time.tm_mday % 10 == 3) ? "rd" : "th", holiday_greeting().first))
+        .add_spacer("small")
+        /* IOTM goes here. but it's P2W, so i will not add. */
+        .add_textbox("Love is popping, hearts are dropping, and we are officially in the `@Valentine's`` spirit! `@Valentine's Week`` has arrived, bringing sweet surprises, shiny rewards ready to steal your heart!")
+        .add_spacer("small")
+        .add_textbox("Taking center stage is the fabulous `9Golden Heart Crystal``, a true treasure of love that can be used to create dazzling gold items! Finding it won't be easy, but then again, true love never is! Keep your eyes peeled while breaking a `pHeartstone``, `8Golden Booty Chest``, `8Super Golden Booty Chest``, or taking a chance at the `#Well of Love``, you never know when luck strikes!")
+        .add_spacer("small")
+        .add_textbox("If your heart beats for competition, the `cEssence of Love Daily Challenge`` is calling your name! Show your dedication, place in the top 5, and you'll be rewarded with a `9Golden Heart Crystal`` as proof that love really does pay off!")
+        .add_spacer("small")
+        .add_textbox("Visit our Social Media pages for more Content!")
+        .add_spacer("small")
+        .add_image_button("gazette_DiscordServer", "interface/large/gazette/gazette_5columns_social_btn01.rttex", "7imageslayout", "https://discord.com/invite/zzWHgzaF7J")
+        .add_layout_spacer("7imageslayout")
+        .add_layout_spacer("7imageslayout")
+        .add_layout_spacer("7imageslayout")
+        .add_layout_spacer("7imageslayout")
+        .add_layout_spacer("7imageslayout")
+        .add_layout_spacer("7imageslayout")
+        .add_spacer("small")
+        .add_image_button("gazette_PrivacyPolicy", "interface/large/gazette/gazette_3columns_policy_btn02.rttex", "3imageslayout", "https://www.ubisoft.com/en-us/privacy-policy")
+        .add_image_button("gazette_GrowtopianCode", "interface/large/gazette/gazette_3columns_policy_btn01.rttex", "3imageslayout", "https://support.ubi.com/en-us/growtopia-faqs/the-growtopian-code/")
+        .add_image_button("gazette_TermsofUse", "interface/large/gazette/gazette_3columns_policy_btn03.rttex", "3imageslayout", "https://legal.ubi.com/termsofuse/")
+        .add_quick_exit().add_spacer("small")
+        .end_dialog("gazette", "", "OK");
+
+    packet::create(*event.peer, false, 0, {
+        "OnDialogRequest",
+        dialog
+    });
+}

--- a/include/on/RequestGazette.hpp
+++ b/include/on/RequestGazette.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace on
+{
+    extern void RequestGazette(ENetEvent& event);
+}


### PR DESCRIPTION
Previously, the gazette dialog was built inline inside `enter_game.cpp`, even though the file already had a TODO to move it into a reusable function and call it from both login flow and `/news`.

This change extracts the gazette dialog into a shared helper and reuses it from `enter_game`. It also adds a `/news` command so the same gazette can be opened again manually without duplicating the dialog code.

## Changes
- add `on::RequestGazette` as a shared helper for the gazette dialog
- move the gazette dialog construction out of `enter_game.cpp`
- call `on::RequestGazette(event)` from `enter_game`
- add a new `/news` command that opens the same gazette dialog
- register `/news` in the command map
- update the help command output to include `/news`