### PR TITLE
PR: Prevent TLS crash

### DIFF
--- a/include/https/https.cpp
+++ b/include/https/https.cpp
@@ -3,6 +3,7 @@
 #include "server_data.hpp"
 
 #include <openssl/err.h>
+#include <csignal>
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -32,6 +33,10 @@ void https::listener()
             ERR_print_errors_fp(stderr);
 
     SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+
+#ifdef SIGPIPE
+    std::signal(SIGPIPE, SIG_IGN);
+#endif
 
     SOCKET socket = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 


### PR DESCRIPTION
Previously, if a client rejected the self-signed certificate during the TLS handshake, the HTTPS listener could hit a closed socket and trigger `SIGPIPE` on Unix. Since `SIGPIPE` terminates the process by default, `main.out` could exit even though the client-side verification failure should only affect that single connection.

This change keeps the existing self-signed certificate flow and makes the listener ignore `SIGPIPE` so failed TLS handshakes do not crash the server process.

## Changes
- ignore `SIGPIPE` in the HTTPS listener on Unix
- allow TLS handshake failures from untrusted clients to fail normally without terminating `main.out`

## Proof
Before
<img width="1907" height="638" alt="image" src="https://github.com/user-attachments/assets/6cd471e2-e438-4bd5-93eb-da0bbc7e6dad" />

After
<img width="1917" height="372" alt="image" src="https://github.com/user-attachments/assets/6b8f2e55-b8b4-46ab-81ee-07a092b0051a" />
