### PR TITLE
Reset peer pos on join; fix exit/rejoin flow

### DIFF
--- a/include/action/join_request.cpp
+++ b/include/action/join_request.cpp
@@ -266,6 +266,7 @@ void action::join_request(ENetEvent& event, const std::string& header, const std
                 (pPeer->user_id == world.owner) ? '2' : 
                 (std::ranges::contains(world.admin, pPeer->user_id)) ? 'c' : pPeer->prefix.front();
 
+        pPeer->pos = pPeer->rest_pos;
         pPeer->netid = ++world.netid_counter;
         peers(pPeer->recent_worlds.back(), PEER_SAME_WORLD, [&event, &pPeer, &world](ENetPeer& peer/*send to everyone in world*/) 
         {

--- a/include/action/quit_to_exit.cpp
+++ b/include/action/quit_to_exit.cpp
@@ -13,8 +13,11 @@ void action::quit_to_exit(ENetEvent& event, const std::string& header, bool skip
     std::string message = std::format("`5<`{}{}`` left, `w{}`` others here>``", prefix, pPeer->ltoken[0], world->visitors-1);
     std::string netid = std::format("netID|{}\n", pPeer->netid);
     std::string pId = std::format("pId|{}\n", pPeer->user_id); // @note this is found during OnSpawn 'eid', the value is the same for user_id.
-    peers(pPeer->recent_worlds.back(), PEER_SAME_WORLD, [message, netid, pId](ENetPeer& peer) 
+    peers(pPeer->recent_worlds.back(), PEER_SAME_WORLD, [pPeer, message, netid, pId](ENetPeer& peer) 
     {
+        ::peer *pOthers = static_cast<::peer*>(peer.data);
+        if (pOthers->user_id == pPeer->user_id) return;
+
         packet::create(peer, false, 0, { "OnConsoleMessage", message.c_str() });
         packet::create(peer, false, 0, { "OnRemove", netid.c_str(), pId.c_str() }); // @todo
     });

--- a/include/state/tile_change.cpp
+++ b/include/state/tile_change.cpp
@@ -368,10 +368,26 @@ void tile_change(ENetEvent& event, state state)
                     if (!door_mover(*world, state.punch)) throw std::runtime_error("There's no room to put the door there! You need 2 empty spaces vertically.");
 
                     std::string remember_name = world->name;
-                    action::quit_to_exit(event, "", true); // @todo everyone in world exits
-                    action::join_request(event, "", remember_name); // @todo everyone in world re-joins
-                    
-                    break;
+                    std::vector<ENetPeer*> world_peers = peers(remember_name, PEER_SAME_WORLD);
+
+                    for (ENetPeer *peer : world_peers)
+                    {
+                        if (!peer || peer->state != ENET_PEER_STATE_CONNECTED) continue;
+
+                        ENetEvent peer_event{};
+                        peer_event.peer = peer;
+                        action::quit_to_exit(peer_event, "", true); // @note everyone in world exits
+                    }
+
+                    for (ENetPeer *peer : world_peers)
+                    {
+                        if (!peer || peer->state != ENET_PEER_STATE_CONNECTED) continue;
+
+                        ENetEvent peer_event{};
+                        peer_event.peer = peer;
+                        action::join_request(peer_event, "", remember_name); // @note everyone in world re-joins
+                    }
+                    return;
                 }
                 case 822: // @note Water Bucket
                 {


### PR DESCRIPTION
Set a joining peer's pos from rest_pos when handling join_request to ensure proper spawn location. Update quit_to_exit to capture the leaving peer and avoid sending OnRemove/OnConsoleMessage to the same user by checking peer user_id. In tile_change, replace the single/global quit/join calls with per-peer iterations: collect world peers, call quit_to_exit for each connected peer, then call join_request for each to force a proper exit and rejoin cycle (returns afterward). These changes ensure correct positioning and prevent self-targeted removal messages during world-wide rejoin operations.