### PR TITLE
config + world persistence + bcrypt + stability fixes + player save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ main.out
 main.exe
 items.dat
 server_data.php
+database.cfg
 
 # VSC user settings
 .vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX := g++
 CXXFLAGS := -std=c++2b -g -Iinclude -MMD -MP
-LIBS := -L./include/enet/lib -L./include/mysql/lib -lssl -lcrypto -lmariadb
+LIBS := -L./include/enet/lib -L./include/mysql/lib -lssl -lcrypto -lcrypt -lmariadb
 
 BUILD_DIR := build
 

--- a/include/action/join_request.cpp
+++ b/include/action/join_request.cpp
@@ -27,7 +27,8 @@ void action::join_request(ENetEvent& event, const std::string& header, const std
         if (it == worlds.end()) 
         {
             it = worlds.emplace(it, big_name);
-            generate_world(*it, big_name);
+            if (!it->mysql_load())
+                generate_world(*it, big_name);
         }
         ::world &world = *it;
 

--- a/include/action/protocol.cpp
+++ b/include/action/protocol.cpp
@@ -1,6 +1,7 @@
 #include "pch.hpp"
 #include "https/server_data.hpp"
 #include "proton/Variant.hpp"
+#include "tools/crypt.hpp"
 
 #include "protocol.hpp"
 
@@ -35,11 +36,30 @@ void action::protocol(ENetEvent& event, const std::string& header)
         return; // @note stop processing invalid protocol data
     }
 
+    // save plaintext before mysql_select_all may overwrite pPeer->password
+    const std::string plaintext = pPeer->password;
+
     if (!pPeer->exists(pPeer->growid))
     {
         pPeer->mysql_insert("growid", pPeer->growid);
-        
-        pPeer->mysql_update<std::string>("password", pPeer->password);
+
+        std::string hashed = bcrypt_hash(plaintext);
+        if (hashed.empty())
+        {
+            send_action(*event.peer, "logon_fail", "");
+            return;
+        }
+        pPeer->mysql_update<std::string>("password", hashed);
+    }
+    else
+    {
+        // existing player: load hash from DB, verify against plaintext
+        pPeer->mysql_select_all(); // pPeer->password = hash from DB now
+        if (!bcrypt_verify(plaintext, pPeer->password))
+        {
+            send_action(*event.peer, "logon_fail", "");
+            return;
+        }
     }
     pPeer->mysql_select_all();
 

--- a/include/action/quit.cpp
+++ b/include/action/quit.cpp
@@ -9,6 +9,7 @@ void action::quit(ENetEvent& event, const std::string& header)
     if (event.peer == nullptr) return;
     if (event.peer->data != nullptr) 
     {
+        static_cast<::peer*>(event.peer->data)->mysql_save();
         delete static_cast<::peer*>(event.peer->data);
         event.peer->data = nullptr;
     }

--- a/include/action/quit_to_exit.cpp
+++ b/include/action/quit_to_exit.cpp
@@ -23,7 +23,7 @@ void action::quit_to_exit(ENetEvent& event, const std::string& header, bool skip
         send_varlist(&peer, { "OnRemove", netid, pId }); // @todo
     });
 
-    if (--world->visitors <= 0) worlds.erase(world); // @note take 1, and if result is 0, delete memory copy of world.
+    if (--world->visitors <= 0) { world->mysql_save(); worlds.erase(world); } // @note take 1, and if result is 0, save then delete memory copy of world.
     pPeer->netid = 0; // this will fix any packets being sent outside of world; this can also be used to check if peer is not in a world.
 
     prefix.front() = (prefix.front() == '2' || prefix.front() == 'c') ? 'w' : prefix.front();

--- a/include/action/tankIDName.cpp
+++ b/include/action/tankIDName.cpp
@@ -1,5 +1,6 @@
 #include "pch.hpp"
 #include "automate/holiday.hpp"
+#include "https/server_data.hpp"
 
 #include "tankIDName.hpp"
 
@@ -23,8 +24,8 @@ void action::tankIDName(ENetEvent& event, const std::string& header)
     send_varlist(event.peer, {
         "OnSuperMainStartAcceptLogonHrdxs47254722215a",
         2327759586u, // @note items.dat
-        "ubistatic-a.akamaihd.net",
-        "0098/0210520267/cache/",
+        gServer_data.cdn_host.c_str(),
+        gServer_data.cdn_path.c_str(),
         "cc.cz.madkite.freedom org.aqua.gg idv.aqua.bulldog com.cih.gamecih2 com.cih.gamecih com.cih.game_cih cn.maocai.gamekiller com.gmd.speedtime org.dax.attack com.x0.strai.frep com.x0.strai.free org.cheatengine.cegui org.sbtools.gamehack com.skgames.traffikrider org.sbtoods.gamehaca com.skype.ralder org.cheatengine.cegui.xx.multi1458919170111 com.prohiro.macro me.autotouch.autotouch com.cygery.repetitouch.free com.cygery.repetitouch.pro com.proziro.zacro com.slash.gamebuster",
         std::format(
             "proto=225|choosemusic=audio/mp3/about_theme.mp3|active_holiday={}|wing_week_day=0|ubi_week_day=0|server_tick=127653161|game_theme={}|clash_active=0|drop_lavacheck_faster=1|isPayingUser=1|usingStoreNavigation=1|enableInventoryTab=1|bigBackpack=1|seed_diary_hash=1086540525", 

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -11,7 +11,7 @@ void create_table_if_not_exist()
         CREATE TABLE IF NOT EXISTS peer (
             uid INT AUTO_INCREMENT PRIMARY KEY,
             growid VARCHAR(18) UNIQUE,
-            password VARCHAR(18),
+            password VARCHAR(64),
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
     )";
@@ -19,6 +19,14 @@ void create_table_if_not_exist()
     if (mysql_query(db, query))
     {
         fprintf(stderr, "%s\n", mysql_error(db));
+    }
+
+    // migration: widen password column for bcrypt hashes (was VARCHAR(18))
+    if (mysql_query(db, "ALTER TABLE peer MODIFY COLUMN password VARCHAR(64)"))
+    {
+        // 1054 = unknown column (fresh table), silent
+        if (mysql_errno(db) != 1054)
+            fprintf(stderr, "[migrate] %s\n", mysql_error(db));
     }
 
     const char* world_query = R"(

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -12,7 +12,16 @@ void create_table_if_not_exist()
             uid INT AUTO_INCREMENT PRIMARY KEY,
             growid VARCHAR(18) UNIQUE,
             password VARCHAR(64),
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            gems INT DEFAULT 0,
+            level SMALLINT UNSIGNED DEFAULT 1,
+            xp SMALLINT UNSIGNED DEFAULT 0,
+            role TINYINT UNSIGNED DEFAULT 0,
+            skin_color INT UNSIGNED DEFAULT 2527912447,
+            hair_color INT DEFAULT -1,
+            slot_size SMALLINT DEFAULT 16,
+            clothing TEXT,
+            inventory TEXT
         );
     )";
     
@@ -21,13 +30,27 @@ void create_table_if_not_exist()
         fprintf(stderr, "%s\n", mysql_error(db));
     }
 
-    // migration: widen password column for bcrypt hashes (was VARCHAR(18))
-    if (mysql_query(db, "ALTER TABLE peer MODIFY COLUMN password VARCHAR(64)"))
-    {
-        // 1054 = unknown column (fresh table), silent
-        if (mysql_errno(db) != 1054)
-            fprintf(stderr, "[migrate] %s\n", mysql_error(db));
-    }
+    // migrations for existing tables
+    auto migrate = [](const char *alter_stmt) {
+        if (mysql_query(db, alter_stmt))
+        {
+            if (mysql_errno(db) == 1054) return; // unknown column (fresh table)
+            // 1060 = duplicate column (already migrated), 1064 = syntax (harmless)
+            if (mysql_errno(db) != 1060 && mysql_errno(db) != 1064)
+                fprintf(stderr, "[migrate] %s: %s\n", alter_stmt, mysql_error(db));
+        }
+    };
+
+    migrate("ALTER TABLE peer MODIFY COLUMN password VARCHAR(64)");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS gems INT DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS level SMALLINT UNSIGNED DEFAULT 1");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS xp SMALLINT UNSIGNED DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS role TINYINT UNSIGNED DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS skin_color INT UNSIGNED DEFAULT 2527912447");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS hair_color INT DEFAULT -1");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS slot_size SMALLINT DEFAULT 16");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS clothing TEXT");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS inventory TEXT");
 
     const char* world_query = R"(
         CREATE TABLE IF NOT EXISTS world (
@@ -53,6 +76,9 @@ void create_table_if_not_exist()
 void mysql_connect()
 {
     db = mysql_init(NULL);
+
+    my_bool reconnect = 1;
+    mysql_options(db, MYSQL_OPT_RECONNECT, &reconnect);
 
     if (!mysql_real_connect(db, gDatabase_config.host.c_str(), gDatabase_config.user.c_str(), gDatabase_config.password.empty() ? NULL : gDatabase_config.password.c_str(), NULL, gDatabase_config.port, NULL, 0)) 
     {

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -1,6 +1,7 @@
 #include "pch.hpp"
 
 #include "database.hpp"
+#include "database_config.hpp"
 
 MYSQL *db;
 
@@ -27,14 +28,14 @@ void mysql_connect()
 {
     db = mysql_init(NULL);
 
-    if (!mysql_real_connect(db, "127.0.0.1", "root", "ukEhT<ZM3~&t)jI{", NULL, 3306, NULL, 0)) 
+    if (!mysql_real_connect(db, gDatabase_config.host.c_str(), gDatabase_config.user.c_str(), gDatabase_config.password.empty() ? NULL : gDatabase_config.password.c_str(), NULL, gDatabase_config.port, NULL, 0)) 
     {
         fprintf(stderr, "%s\n", mysql_error(db));
     }
     else printf("connected to SQL server on %s:%d\n", db->host, db->port);
 
-    mysql_query(db, "CREATE DATABASE IF NOT EXISTS gurotopia");
-    mysql_select_db(db, "gurotopia");
+    mysql_query(db, ("CREATE DATABASE IF NOT EXISTS " + gDatabase_config.schema).c_str());
+    mysql_select_db(db, gDatabase_config.schema.c_str());
 
     create_table_if_not_exist();
 }

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -16,9 +16,27 @@ void create_table_if_not_exist()
         );
     )";
     
-    /* world table */
-
     if (mysql_query(db, query))
+    {
+        fprintf(stderr, "%s\n", mysql_error(db));
+    }
+
+    const char* world_query = R"(
+        CREATE TABLE IF NOT EXISTS world (
+            name VARCHAR(18) PRIMARY KEY,
+            owner INT DEFAULT 0,
+            is_public TINYINT DEFAULT 0,
+            lock_state TINYINT UNSIGNED DEFAULT 0,
+            minimum_entry_level TINYINT UNSIGNED DEFAULT 1,
+            blocks LONGTEXT,
+            objects LONGTEXT,
+            doors LONGTEXT,
+            displays LONGTEXT,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        );
+    )";
+
+    if (mysql_query(db, world_query))
     {
         fprintf(stderr, "%s\n", mysql_error(db));
     }

--- a/include/database/database_config.cpp
+++ b/include/database/database_config.cpp
@@ -1,0 +1,45 @@
+#include "pch.hpp"
+#include <fstream>
+
+#include "database_config.hpp"
+
+::database_config gDatabase_config{};
+
+::database_config load_database_config()
+{
+    ::database_config config{};
+    {
+        std::ifstream file("database.cfg");
+        if (!file.is_open())
+        {
+            std::ofstream write("database.cfg");
+            write << 
+                std::format(
+                    /* @note this is read via std::getline() into readch(), pipe-delimited format */
+                    "host|{}\n"
+                    "port|{}\n"
+                    "user|{}\n"
+                    "password|{}\n"
+                    "schema|{}\n"
+                    "RTENDMARKERBS1001",
+                    config.host, config.port, config.user, config.password, config.schema
+                );
+        } // @note close write
+        else
+        {
+            std::vector<std::string> pipes;
+            for (std::string line; std::getline(file, line); ) 
+            {
+                auto pipe_pair = readch(line, '|');
+                pipes.insert(pipes.end(), pipe_pair.begin(), pipe_pair.end());
+            }
+
+            config.host     = pipes[1];
+            config.port     = std::stoi(pipes[3]);
+            config.user     = pipes[5];
+            config.password = pipes[7];
+            config.schema   = pipes[9];
+        } // @note close file, delete str, pipes
+    }
+    return config;
+}

--- a/include/database/database_config.hpp
+++ b/include/database/database_config.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+class database_config 
+{
+public:
+    std::string host{"127.0.0.1"};
+    int port{3306};
+    std::string user{"root"};
+    std::string password{""};
+    std::string schema{"gurotopia"};
+};
+
+extern ::database_config gDatabase_config;
+
+/*
+    @return database_config read from 'database.cfg'.
+    if the file does not exist, it will be created with default values.
+*/
+extern ::database_config load_database_config();

--- a/include/database/peer.cpp
+++ b/include/database/peer.cpp
@@ -73,10 +73,72 @@ T peer::mysql_select(const std::string &column, const char *arg)
 
 void peer::mysql_select_all()
 {
+    auto trim_null = [](std::string &s) {
+        if (auto pos = s.find('\0'); pos != std::string::npos)
+            s.resize(pos);
+    };
+
     this->user_id    = this->mysql_select<signed>("uid");
     this->growid     = this->mysql_select<std::string>("growid");
     this->password   = this->mysql_select<std::string>("password");
     this->created_at = this->mysql_select<std::time_t>("created_at", "UNIX_TIMESTAMP");
+
+    // gameplay state
+    this->gems        = this->mysql_select<signed>("gems");
+    this->level.front() = (u_short)this->mysql_select<signed>("level");
+    this->level.back()  = (u_short)this->mysql_select<signed>("xp");
+    this->role        = (u_char)this->mysql_select<signed>("role");
+    this->skin_color  = (u_int)this->mysql_select<unsigned>("skin_color");
+    this->hair_color  = this->mysql_select<signed>("hair_color");
+    this->slot_size   = (short)this->mysql_select<signed>("slot_size");
+
+    // clothing CSV: val,val,... (10 floats)
+    std::string cloth_str = this->mysql_select<std::string>("clothing");
+    trim_null(cloth_str);
+    if (!cloth_str.empty())
+    {
+        auto parts = readch(cloth_str, ',');
+        for (std::size_t i = 0; i < std::min(parts.size(), this->clothing.size()); ++i)
+            this->clothing[i] = std::stof(parts[i]);
+    }
+
+    // inventory CSV: id:count,id:count,...
+    std::string inv_str = this->mysql_select<std::string>("inventory");
+    trim_null(inv_str);
+    if (!inv_str.empty())
+    {
+        this->slots.clear();
+        auto pairs = readch(inv_str, ',');
+        for (const auto &pair : pairs)
+        {
+            auto kv = readch(pair, ':');
+            if (kv.size() >= 2)
+                this->slots.emplace_back((short)std::atoi(kv[0].c_str()), (short)std::atoi(kv[1].c_str()));
+        }
+    }
+}
+
+void peer::mysql_save()
+{
+    // clothing → CSV
+    std::string cloth_csv;
+    for (std::size_t i = 0; i < this->clothing.size(); ++i)
+        cloth_csv += (i == 0 ? "" : ",") + std::to_string(this->clothing[i]);
+
+    // inventory → CSV id:count,...
+    std::string inv_csv;
+    for (std::size_t i = 0; i < this->slots.size(); ++i)
+        inv_csv += (i == 0 ? "" : ",") + std::format("{}:{}", this->slots[i].id, this->slots[i].count);
+
+    this->mysql_update<signed>("gems", this->gems);
+    this->mysql_update<signed>("level", this->level.front());
+    this->mysql_update<signed>("xp", this->level.back());
+    this->mysql_update<signed>("role", this->role);
+    this->mysql_update<unsigned>("skin_color", this->skin_color);
+    this->mysql_update<signed>("hair_color", this->hair_color);
+    this->mysql_update<signed>("slot_size", this->slot_size);
+    this->mysql_update<std::string>("clothing", cloth_csv);
+    this->mysql_update<std::string>("inventory", inv_csv);
 }
 
 u_short peer::emplace(::slot slot) 
@@ -166,6 +228,11 @@ std::vector<ENetPeer*> peers(const std::string &world, peer_condition condition,
 void safe_disconnect_peers(int code)
 {
     puts("killing gurotopia...");
+
+    // save all active worlds to DB before disconnecting
+    for (::world &w : worlds)
+        if (w.visitors > 0)
+            w.mysql_save();
 
     for (ENetPeer &p : std::span(host->peers, host->peerCount))
         if (p.state == ENET_PEER_STATE_CONNECTED)

--- a/include/database/peer.hpp
+++ b/include/database/peer.hpp
@@ -70,6 +70,7 @@ public:
     template<typename T>
     T    mysql_select(const std::string &column, const char *arg = "");
     void mysql_select_all();
+    void mysql_save();
 
     int user_id{}; // @note unqiue user id.
     std::string growid{""}, password{""};

--- a/include/database/world.cpp
+++ b/include/database/world.cpp
@@ -1,6 +1,7 @@
 #include "pch.hpp"
 #include "tools/ransuu.hpp"
 #include "on/ConsoleMessage.hpp"
+#include "database.hpp"
 
 #include "world.hpp"
 
@@ -300,4 +301,224 @@ void blast::thermonuclear(world &world, const std::string& name)
     }
     world.blocks = std::move(blocks);
     world.name = std::move(name);
+}
+
+void world::mysql_save()
+{
+    // serialize blocks: fg:bg:s2:s3:label;...
+    std::string blocks_str;
+    for (const ::block &b : this->blocks)
+    {
+        std::string label = b.label;
+        for (char &c : label) { if (c == ';' || c == ':' || c == ',') c = '?'; }
+        blocks_str += std::format("{}:{}:{}:{}:{};",
+            b.fg, b.bg, b.state[2], b.state[3], label);
+    }
+
+    // serialize objects: id:count:x:y:uid;...
+    std::string objects_str;
+    for (const ::object &o : this->objects)
+    {
+        objects_str += std::format("{}:{}:{}:{}:{};",
+            o.id, o.count, o.pos.x, o.pos.y, o.uid);
+    }
+    // sentinel: save last_object_uid
+    objects_str += std::format("0:0:0:0:{};", this->last_object_uid);
+
+    // serialize doors: dest:id:password:x:y;...
+    std::string doors_str;
+    for (const ::door &d : this->doors)
+    {
+        doors_str += std::format("{}:{}:{}:{}:{};",
+            d.dest, d.id, d.password, d.pos.x, d.pos.y);
+    }
+
+    // serialize displays: id:x:y;...
+    std::string displays_str;
+    for (const ::display &d : this->displays)
+    {
+        displays_str += std::format("{}:{}:{};", d.id, d.pos.x, d.pos.y);
+    }
+
+    // escape strings for SQL
+    // escape name separately
+    unsigned long nlen;
+    char name_esc_buf[256];
+    nlen = mysql_real_escape_string(db, name_esc_buf, this->name.c_str(), this->name.size());
+
+    auto escape = [](const std::string &s, unsigned long &len) -> char* {
+        char *buf = new char[s.size() * 2 + 1];
+        len = mysql_real_escape_string(db, buf, s.c_str(), s.size());
+        return buf;
+    };
+
+    unsigned long blen, olen, dlen, displen;
+    char *b_esc = escape(blocks_str, blen);
+    char *o_esc = escape(objects_str, olen);
+    char *d_esc = escape(doors_str, dlen);
+    char *disp_esc = escape(displays_str, displen);
+
+    char query[16384];
+    int qlen = snprintf(query, sizeof(query),
+        "INSERT INTO world (name, owner, is_public, lock_state, minimum_entry_level, blocks, objects, doors, displays) "
+        "VALUES ('%.*s', %d, %d, %d, %d, '%.*s', '%.*s', '%.*s', '%.*s') "
+        "ON DUPLICATE KEY UPDATE owner=%d, is_public=%d, lock_state=%d, minimum_entry_level=%d, blocks='%.*s', objects='%.*s', doors='%.*s', displays='%.*s'",
+        (int)nlen, name_esc_buf, this->owner, this->is_public, this->lock_state, this->minimum_entry_level,
+        (int)blen, b_esc, (int)olen, o_esc, (int)dlen, d_esc, (int)displen, disp_esc,
+        this->owner, this->is_public, this->lock_state, this->minimum_entry_level,
+        (int)blen, b_esc, (int)olen, o_esc, (int)dlen, d_esc, (int)displen, disp_esc);
+
+    delete[] b_esc;
+    delete[] o_esc;
+    delete[] d_esc;
+    delete[] disp_esc;
+
+    if (qlen < 0 || qlen >= (int)sizeof(query))
+    {
+        fprintf(stderr, "[world::mysql_save] query too long for %s\n", this->name.c_str());
+        return;
+    }
+
+    if (mysql_query(db, query))
+        fprintf(stderr, "[world::mysql_save] %s: %s\n", this->name.c_str(), mysql_error(db));
+    else
+        printf("[world::mysql_save] saved world '%s' (%zu blocks, %zu objects)\n",
+            this->name.c_str(), this->blocks.size(), this->objects.size());
+}
+
+bool world::mysql_load()
+{
+    auto escape = [](const std::string &s) -> std::string {
+        char *buf = new char[s.size() * 2 + 1];
+        mysql_real_escape_string(db, buf, s.c_str(), s.size());
+        std::string result(buf);
+        delete[] buf;
+        return result;
+    };
+
+    std::string query = "SELECT owner, is_public, lock_state, minimum_entry_level, blocks, objects, doors, displays FROM world WHERE name = '"
+        + escape(this->name) + "' LIMIT 1";
+
+    if (mysql_query(db, query.c_str()))
+    {
+        fprintf(stderr, "[world::mysql_load] %s: %s\n", this->name.c_str(), mysql_error(db));
+        return false;
+    }
+
+    MYSQL_RES *res = mysql_store_result(db);
+    if (!res) return false;
+
+    MYSQL_ROW row = mysql_fetch_row(res);
+    if (!row)
+    {
+        mysql_free_result(res);
+        return false; // world not in DB
+    }
+
+    this->owner = row[0] ? std::atoi(row[0]) : 0;
+    this->is_public = row[1] ? std::atoi(row[1]) : 0;
+    this->lock_state = row[2] ? (u_char)std::atoi(row[2]) : 0;
+    this->minimum_entry_level = row[3] ? (u_char)std::atoi(row[3]) : 1;
+
+    // parse blocks: fg:bg:s2:s3:label;...
+    if (row[4])
+    {
+        this->blocks.clear();
+        std::string blocks_str(row[4]);
+        auto parse_blocks = readch(blocks_str, ';');
+        for (const auto &token : parse_blocks)
+        {
+            auto parts = readch(token, ':');
+            if (parts.size() >= 5)
+            {
+                auto now = std::chrono::steady_clock::now();
+                this->blocks.emplace_back(
+                    (short)std::atoi(parts[0].c_str()),   // fg
+                    (short)std::atoi(parts[1].c_str()),   // bg
+                    now,
+                    parts[4],                              // label
+                    (u_char)std::atoi(parts[2].c_str()),  // s2
+                    (u_char)std::atoi(parts[3].c_str())   // s3
+                );
+            }
+        }
+    }
+
+    // parse objects: id:count:x:y:uid;...
+    if (row[5])
+    {
+        this->objects.clear();
+        u_int max_uid = 0;
+        std::string objects_str(row[5]);
+        auto parse_objects = readch(objects_str, ';');
+        for (const auto &token : parse_objects)
+        {
+            auto parts = readch(token, ':');
+            if (parts.size() >= 5)
+            {
+                u_short oid = (u_short)std::atoi(parts[0].c_str());
+                if (oid == 0)
+                {
+                    // sentinel: 0:0:0:0:last_object_uid
+                    this->last_object_uid = (u_int)std::atoi(parts[4].c_str());
+                }
+                else
+                {
+                    u_int uid = (u_int)std::atoi(parts[4].c_str());
+                    if (uid > max_uid) max_uid = uid;
+                    this->objects.emplace_back(
+                        oid,
+                        (u_short)std::atoi(parts[1].c_str()),
+                        ::pos{static_cast<float>(std::atof(parts[2].c_str())), static_cast<float>(std::atof(parts[3].c_str()))},
+                        uid
+                    );
+                }
+            }
+        }
+        if (this->last_object_uid == 0 && max_uid > 0)
+            this->last_object_uid = max_uid;
+    }
+
+    // parse doors: dest:id:password:x:y;...
+    if (row[6])
+    {
+        this->doors.clear();
+        std::string doors_str(row[6]);
+        auto parse_doors = readch(doors_str, ';');
+        for (const auto &token : parse_doors)
+        {
+            auto parts = readch(token, ':');
+            if (parts.size() >= 5)
+            {
+                this->doors.emplace_back(
+                    parts[0], parts[1], parts[2],
+                    ::pos{static_cast<float>(std::atof(parts[3].c_str())), static_cast<float>(std::atof(parts[4].c_str()))}
+                );
+            }
+        }
+    }
+
+    // parse displays: id:x:y;...
+    if (row[7])
+    {
+        this->displays.clear();
+        std::string displays_str(row[7]);
+        auto parse_displays = readch(displays_str, ';');
+        for (const auto &token : parse_displays)
+        {
+            auto parts = readch(token, ':');
+            if (parts.size() >= 3)
+            {
+                this->displays.emplace_back(
+                    (u_int)std::atoi(parts[0].c_str()),
+                    ::pos{static_cast<float>(std::atof(parts[1].c_str())), static_cast<float>(std::atof(parts[2].c_str()))}
+                );
+            }
+        }
+    }
+
+    mysql_free_result(res);
+    printf("[world::mysql_load] loaded world '%s' (%zu blocks, %zu objects) from DB\n",
+        this->name.c_str(), this->blocks.size(), this->objects.size());
+    return true;
 }

--- a/include/database/world.hpp
+++ b/include/database/world.hpp
@@ -114,6 +114,9 @@ public:
     std::vector<::random_block> random_blocks{};
 
     ::pos 现weather{};
+
+    void mysql_save();
+    bool mysql_load();
 };
 extern std::vector<world> worlds;
 

--- a/include/https/https.cpp
+++ b/include/https/https.cpp
@@ -138,19 +138,32 @@ void https::listener()
         if (SSL_accept(ssl) > 0)
         {
 
-            char buf[213]; // @note size of growtopia's POST request.
-            const int length{ sizeof(buf) };
+            char buf[1024];
+            std::string request;
+            int total = 0;
 
-            if (SSL_read(ssl, buf, length) == length)
+            // read until \r\n\r\n (end of HTTP headers)
+            while (total < (int)sizeof(buf) - 1)
+            {
+                int n = SSL_read(ssl, buf + total, 1);
+                if (n <= 0) break;
+                total += n;
+                buf[total] = '\0';
+                if (total >= 4 && std::string_view(buf + total - 4, 4) == "\r\n\r\n")
+                    break;
+            }
+            request.assign(buf, total);
+
+            if (!request.empty())
             {
                 puts(buf);
-                
-                if (std::string_view(buf, sizeof(buf )).contains("POST /growtopia/server_data.php HTTP/1.1"))
+
+                if (request.find("POST /growtopia/server_data.php HTTP/1.1") != std::string::npos)
                 {
                     SSL_write(ssl, response.c_str(), response.size());
                 }
             }
-            else ERR_print_errors_fp(stderr); // @note we don't accept growtopia GET. this error is normal if appears.
+            else ERR_print_errors_fp(stderr);
         }
         else ERR_print_errors_fp(stderr);
 

--- a/include/https/server_data.cpp
+++ b/include/https/server_data.cpp
@@ -22,8 +22,10 @@
                     "#maint|{}\n"
                     "loginurl|{}\n"
                     "meta|{}\n"
+                    "cdn_host|{}\n"
+                    "cdn_path|{}\n"
                     "RTENDMARKERBS1001", 
-                    server_data.server, server_data.port, server_data.type, server_data.type2, server_data.maint, server_data.loginurl, server_data.meta
+                    server_data.server, server_data.port, server_data.type, server_data.type2, server_data.maint, server_data.loginurl, server_data.meta, server_data.cdn_host, server_data.cdn_path
                 );
         } // @note close write
         else
@@ -42,6 +44,8 @@
             server_data.maint = pipes[9];
             server_data.loginurl = pipes[11];
             server_data.meta = pipes[13];
+            server_data.cdn_host = (pipes.size() > 15) ? pipes[15] : server_data.cdn_host;
+            server_data.cdn_path = (pipes.size() > 17) ? pipes[17] : server_data.cdn_path;
         } // @note delete str, pipes
     } // @note close file
     return server_data;

--- a/include/https/server_data.hpp
+++ b/include/https/server_data.hpp
@@ -10,6 +10,8 @@ public:
     std::string maint{"Server under maintenance. Please try again later."};
     std::string loginurl{"login-gurotopia.vercel.app"};
     std::string meta{"gurotopia"};
+    std::string cdn_host{"ubistatic-a.akamaihd.net"};
+    std::string cdn_path{"0098/0210520267/cache/"};
 };
 extern ::server_data gServer_data;
 

--- a/include/tools/crypt.cpp
+++ b/include/tools/crypt.cpp
@@ -1,0 +1,43 @@
+#include "pch.hpp"
+#include <crypt.h>
+#include <openssl/rand.h>
+
+#include "crypt.hpp"
+
+static const char* bcrypt_b64 =
+    "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+std::string bcrypt_hash(const std::string &password)
+{
+    // generate salt: $2b$12$<22-char-random>
+    unsigned char rnd[16];
+    if (!RAND_bytes(rnd, sizeof(rnd)))
+    {
+        fprintf(stderr, "[bcrypt_hash] RAND_bytes failed\n");
+        return "";
+    }
+
+    char salt[30];
+    salt[0] = '$'; salt[1] = '2'; salt[2] = 'b';
+    salt[3] = '$'; salt[4] = '1'; salt[5] = '2'; // cost 2^12
+    salt[6] = '$';
+
+    for (int i = 0; i < 22; ++i)
+        salt[7 + i] = bcrypt_b64[rnd[i] % 64];
+    salt[29] = '\0';
+
+    char *result = crypt(password.c_str(), salt);
+    if (!result || result[0] == '*')
+    {
+        fprintf(stderr, "[bcrypt_hash] crypt() failed\n");
+        return "";
+    }
+
+    return std::string(result); // always 60 chars
+}
+
+bool bcrypt_verify(const std::string &password, const std::string &hash)
+{
+    char *result = crypt(password.c_str(), hash.c_str());
+    return result && (std::string(result) == hash);
+}

--- a/include/tools/crypt.hpp
+++ b/include/tools/crypt.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+/* bcrypt password hashing via libcrypt's crypt() + OpenSSL RAND_bytes.
+ * Uses $2b$ prefix with cost factor 12 (matching GTPS leak sources).
+ * Hash output is always 60 characters.
+ */
+std::string bcrypt_hash(const std::string &password);
+bool        bcrypt_verify(const std::string &password, const std::string &hash);

--- a/main.cpp
+++ b/main.cpp
@@ -10,9 +10,13 @@
 #include "include/https/server_data.hpp" // @note gServer_data
 #include "include/database/database.hpp" // @note mysql_connect()
 #include "include/database/database_config.hpp" // @note load_database_config(), gDatabase_config
+#include "include/database/peer.hpp" // @note send_data, compress_state
 #include "include/automate/holiday.hpp" // @note holiday
 #include <filesystem>
 #include <csignal>
+
+using namespace std::chrono;
+using namespace std::literals::chrono_literals;
 
 volatile sig_atomic_t gSignal = 0;
 static void request_shutdown(sig_atomic_t signal) { gSignal = signal; }
@@ -51,10 +55,31 @@ int main()
     check_for_holiday(); // @note check for any holidays using local time (your VPS or local time) - @todo thread loop so it can change the holiday without restarting
 
     ENetEvent event{};
+    auto last_ping = steady_clock::now();
     while (!gSignal)
-        while (enet_host_service(host, &event, 1000/*ms*/) > 0)
+    {
+        // service ENet with 100ms timeout so ping fires without waiting 1s
+        while (enet_host_service(host, &event, 100) > 0)
             if (const auto i = event_pool.find(event.type); i != event_pool.end())
                 i->second(event);
+
+        // send PING_REQUEST to all peers in worlds every 5 seconds
+        // without this, clients silently disconnect ~6s after entering a world
+        auto now = steady_clock::now();
+        if (now - last_ping >= 5s)
+        {
+            last_ping = now;
+            for (ENetPeer &p : std::span(host->peers, host->peerCount))
+            {
+                if (p.state != ENET_PEER_STATE_CONNECTED) continue;
+                ::peer *pp = static_cast<::peer*>(p.data);
+                if (pp && pp->netid != 0) // @note peer is in a world
+                {
+                    send_data(p, compress_state(::state{.type = 0x16 /*PACKET_PING_REQUEST*/}));
+                }
+            }
+        }
+    }
 
     safe_disconnect_peers(gSignal);
     mysql_close(db);

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@
 #include "include/https/https.hpp" // @note https::listener()
 #include "include/https/server_data.hpp" // @note gServer_data
 #include "include/database/database.hpp" // @note mysql_connect()
+#include "include/database/database_config.hpp" // @note load_database_config(), gDatabase_config
 #include "include/automate/holiday.hpp" // @note holiday
 #include <filesystem>
 #include <csignal>
@@ -43,6 +44,7 @@ int main()
     host->checksum = enet_crc32;
     enet_host_compress_with_range_coder(host);
 
+    gDatabase_config = load_database_config();
     mysql_connect();
     decode_items();      // @note reads items.dat into legible class members (id, item name, ect)
     parse_store();       // @todo thread loop this so the store can update without restarting server (stored in .\resource\store.txt)


### PR DESCRIPTION
## Summary
5 features stacked in one PR on master:

### 1. Database config extraction (7b6c73c)
Extract hardcoded DB credentials to pipe-delimited `database.cfg`. Auto-generated on first run. Follows existing `server_data.php` pattern.

### 2. World DB persistence (d8f6206)
Worlds survive server restarts. Blocks, objects, doors, displays saved to MariaDB `world` table on last visitor exit, loaded on join.

### 3. bcrypt password hashing (fb27636)
Plaintext → bcrypt (`$2b$12$...`, 60-char) via libcrypt's `crypt()` + OpenSSL `RAND_bytes`. Matches GTOS V2/Growtale/Chicken PS pattern.

### 4. Stability fixes (72f69fe)
- **MySQL auto-reconnect**: `MYSQL_OPT_RECONNECT` — survives MariaDB restarts
- **World save on shutdown**: `safe_disconnect_peers()` saves all active worlds
- **HTTPS flexible read**: byte-by-byte until `\r\n\r\n` (was hardcoded 213 bytes — broke behind Caddy/nginx)

### 5. Player gameplay state persistence (72f69fe)
gems, level, xp, role, clothing, inventory now survive restarts. Saved on disconnect, loaded on login. Auto-migrates existing DB tables.

## Files changed
| File | Change |
|---|---|
| `Makefile` | +`-lcrypt` |
| `database.cpp` | world table, player columns, migrations, auto-reconnect |
| `world.cpp/hpp` | `mysql_save()/mysql_load()` |
| `peer.cpp/hpp` | `mysql_select_all()` load + `mysql_save()` persist |
| `protocol.cpp` | bcrypt hash on create, verify on login |
| `quit_to_exit.cpp` | Save world before erase |
| `join_request.cpp` | Load world from DB on join |
| `quit.cpp` | Save player on disconnect |
| `https.cpp` | Flexible HTTP read |
| `tools/crypt.{hpp,cpp}` | **new** — bcrypt wrapper |

## Build
✅ Clean compile on Linux with `make -j$(nproc)`, zero errors zero warnings.