### PR TITLE
config: extract database credentials to pipe-delimited database.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ main.out
 main.exe
 items.dat
 server_data.php
+database.cfg
 
 # VSC user settings
 .vscode/settings.json

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -1,6 +1,7 @@
 #include "pch.hpp"
 
 #include "database.hpp"
+#include "database_config.hpp"
 
 MYSQL *db;
 
@@ -27,14 +28,14 @@ void mysql_connect()
 {
     db = mysql_init(NULL);
 
-    if (!mysql_real_connect(db, "127.0.0.1", "root", "ukEhT<ZM3~&t)jI{", NULL, 3306, NULL, 0)) 
+    if (!mysql_real_connect(db, gDatabase_config.host.c_str(), gDatabase_config.user.c_str(), gDatabase_config.password.empty() ? NULL : gDatabase_config.password.c_str(), NULL, gDatabase_config.port, NULL, 0)) 
     {
         fprintf(stderr, "%s\n", mysql_error(db));
     }
     else printf("connected to SQL server on %s:%d\n", db->host, db->port);
 
-    mysql_query(db, "CREATE DATABASE IF NOT EXISTS gurotopia");
-    mysql_select_db(db, "gurotopia");
+    mysql_query(db, ("CREATE DATABASE IF NOT EXISTS " + gDatabase_config.schema).c_str());
+    mysql_select_db(db, gDatabase_config.schema.c_str());
 
     create_table_if_not_exist();
 }

--- a/include/database/database_config.cpp
+++ b/include/database/database_config.cpp
@@ -1,0 +1,45 @@
+#include "pch.hpp"
+#include <fstream>
+
+#include "database_config.hpp"
+
+::database_config gDatabase_config{};
+
+::database_config load_database_config()
+{
+    ::database_config config{};
+    {
+        std::ifstream file("database.cfg");
+        if (!file.is_open())
+        {
+            std::ofstream write("database.cfg");
+            write << 
+                std::format(
+                    /* @note this is read via std::getline() into readch(), pipe-delimited format */
+                    "host|{}\n"
+                    "port|{}\n"
+                    "user|{}\n"
+                    "password|{}\n"
+                    "schema|{}\n"
+                    "RTENDMARKERBS1001",
+                    config.host, config.port, config.user, config.password, config.schema
+                );
+        } // @note close write
+        else
+        {
+            std::vector<std::string> pipes;
+            for (std::string line; std::getline(file, line); ) 
+            {
+                auto pipe_pair = readch(line, '|');
+                pipes.insert(pipes.end(), pipe_pair.begin(), pipe_pair.end());
+            }
+
+            config.host     = pipes[1];
+            config.port     = std::stoi(pipes[3]);
+            config.user     = pipes[5];
+            config.password = pipes[7];
+            config.schema   = pipes[9];
+        } // @note close file, delete str, pipes
+    }
+    return config;
+}

--- a/include/database/database_config.hpp
+++ b/include/database/database_config.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+class database_config 
+{
+public:
+    std::string host{"127.0.0.1"};
+    int port{3306};
+    std::string user{"root"};
+    std::string password{""};
+    std::string schema{"gurotopia"};
+};
+
+extern ::database_config gDatabase_config;
+
+/*
+    @return database_config read from 'database.cfg'.
+    if the file does not exist, it will be created with default values.
+*/
+extern ::database_config load_database_config();

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@
 #include "include/https/https.hpp" // @note https::listener()
 #include "include/https/server_data.hpp" // @note gServer_data
 #include "include/database/database.hpp" // @note mysql_connect()
+#include "include/database/database_config.hpp" // @note load_database_config(), gDatabase_config
 #include "include/automate/holiday.hpp" // @note holiday
 #include <filesystem>
 #include <csignal>
@@ -43,6 +44,7 @@ int main()
     host->checksum = enet_crc32;
     enet_host_compress_with_range_coder(host);
 
+    gDatabase_config = load_database_config();
     mysql_connect();
     decode_items();      // @note reads items.dat into legible class members (id, item name, ect)
     parse_store();       // @todo thread loop this so the store can update without restarting server (stored in .\resource\store.txt)


### PR DESCRIPTION
Extract hardcoded DB creds to pipe-delimited database.cfg. Auto-generated on first run. No external deps.