### PR TITLE
feat: admin commands — ban, mute, kick, give, setgems, setrole

### DIFF
--- a/include/action/input.cpp
+++ b/include/action/input.cpp
@@ -17,6 +17,12 @@ void action::input(ENetEvent& event, const std::string& header)
     text.erase(std::find_if_not(text.rbegin(), text.rend(), ::isspace).base(), text.end());
     if (text.empty()) return; // @note we recheck if empty since we did trimming.
     
+    if (pPeer->muted)
+    {
+        on::ConsoleMessage(event.peer, "`4You are muted.``");
+        return;
+    }
+
     steady_clock::time_point now = steady_clock::now();
     pPeer->messages.push_back(now);
     if (pPeer->messages.size() > 5) pPeer->messages.pop_front();

--- a/include/action/protocol.cpp
+++ b/include/action/protocol.cpp
@@ -43,6 +43,14 @@ void action::protocol(ENetEvent& event, const std::string& header)
     }
     pPeer->mysql_select_all();
 
+    // ban check
+    if (pPeer->banned)
+    {
+        send_action(*event.peer, "logon_fail", "");
+        enet_peer_disconnect_later(event.peer, 0);
+        return;
+    }
+
     send_varlist(event.peer, {
         "OnSendToServer", 
         (int)gServer_data.port, 

--- a/include/action/quit.cpp
+++ b/include/action/quit.cpp
@@ -9,6 +9,7 @@ void action::quit(ENetEvent& event, const std::string& header)
     if (event.peer == nullptr) return;
     if (event.peer->data != nullptr) 
     {
+        static_cast<::peer*>(event.peer->data)->mysql_save();
         delete static_cast<::peer*>(event.peer->data);
         event.peer->data = nullptr;
     }

--- a/include/commands/__command.cpp
+++ b/include/commands/__command.cpp
@@ -11,12 +11,13 @@
 #include "weather.hpp"
 #include "ghost.hpp"
 #include "ageworld.hpp"
+#include "admin.hpp"
 #include "__command.hpp"
 
 /* if you plan to use this outside of this file, please include in __command.hpp (^-^) - and just make it a void. */
 auto help_return = [](ENetEvent& event, const std::string_view text) 
 {
-    send_action(*event.peer, "log", "msg|>> Commands: /find /warp {world} /punch {id} /skin {id} /sb {msg} /who /me {msg} /news /weather {id} /ghost /ageworld /wave /dance /love /sleep /facepalm /fp /smh /yes /no /omg /idk /shrug /furious /rolleyes /foldarms /stubborn /fold /dab /sassy /dance2 /march /grumpy /shy \0");
+    send_action(*event.peer, "log", "msg|>> Commands: /find /warp {world} /punch {id} /skin {id} /sb {msg} /who /me {msg} /news /weather {id} /ghost /ageworld /give {growid} {id} {count} /setgems {growid} {amt} /ban {growid} /unban {growid} /mute {growid} /unmute {growid} /kick {growid} /setrole {growid} {role} /wave /dance /love /sleep /facepalm /fp /smh /yes /no /omg /idk /shrug /furious /rolleyes /foldarms /stubborn /fold /dab /sassy /dance2 /march /grumpy /shy \0");
 };
 
 std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::string_view)>> cmd_pool
@@ -34,6 +35,14 @@ std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::s
     {"weather", &weather},
     {"ghost", &ghost},
     {"ageworld", &ageworld},
+    {"give", &give},
+    {"setgems", &setgems},
+    {"ban", &ban},
+    {"unban", &unban},
+    {"mute", &mute},
+    {"unmute", &unmute},
+    {"kick", &kick},
+    {"setrole", &setrole},
     {"wave", &on::Action}, {"dance", &on::Action}, {"love", &on::Action}, {"sleep", &on::Action}, {"facepalm", &on::Action}, {"fp", &on::Action}, 
     {"smh", &on::Action}, {"yes", &on::Action}, {"no", &on::Action}, {"omg", &on::Action}, {"idk", &on::Action}, {"shrug", &on::Action}, 
     {"furious", &on::Action}, {"rolleyes", &on::Action}, {"foldarms", &on::Action}, {"fa", &on::Action}, {"stubborn", &on::Action}, {"fold", &on::Action}, 

--- a/include/commands/__command.hpp
+++ b/include/commands/__command.hpp
@@ -4,3 +4,4 @@
 
 extern std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::string_view)>> cmd_pool;
 
+#include "admin.hpp"

--- a/include/commands/admin.cpp
+++ b/include/commands/admin.cpp
@@ -1,0 +1,363 @@
+#include "pch.hpp"
+#include "on/ConsoleMessage.hpp"
+#include "on/NameChanged.hpp"
+#include "database/database.hpp"
+
+#include "admin.hpp"
+
+/* find online peer by growid (case-insensitive) */
+static ::peer* find_peer_by_growid(const std::string_view growid)
+{
+    for (ENetPeer &p : std::span(host->peers, host->peerCount))
+    {
+        if (p.state != ENET_PEER_STATE_CONNECTED) continue;
+        ::peer *pp = static_cast<::peer*>(p.data);
+        if (!pp) continue;
+
+        // case-insensitive compare
+        if (pp->growid.size() == growid.size())
+        {
+            bool match = true;
+            for (std::size_t i = 0; i < growid.size(); ++i)
+                if (std::tolower(pp->growid[i]) != std::tolower(growid[i]))
+                    { match = false; break; }
+            if (match) return pp;
+        }
+    }
+    return nullptr;
+}
+
+/* extract 2nd word from text after command name */
+static std::string get_arg(const std::string_view text, int n = 1)
+{
+    auto parts = readch(std::string(text), ' ');
+    if (parts.size() > (size_t)n) return parts[n];
+    return "";
+}
+
+void give(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    auto parts = readch(std::string(text), ' ');
+    if (parts.size() < 4)
+    {
+        on::ConsoleMessage(event.peer, "Usage: /give {growid} {itemid} {count}");
+        return;
+    }
+
+    std::string target_name = parts[1];
+    short item_id = (short)std::atoi(parts[2].c_str());
+    short count = (short)std::atoi(parts[3].c_str());
+
+    if (item_id <= 0 || count <= 0 || count > 200)
+    {
+        on::ConsoleMessage(event.peer, "`4Invalid item ID or count (1-200).``");
+        return;
+    }
+
+    ::peer *target = find_peer_by_growid(target_name);
+    if (!target)
+    {
+        on::ConsoleMessage(event.peer, std::format("`4Player '{}' not found or offline.``", target_name));
+        return;
+    }
+
+    // create a fake event pointing to target peer
+    ENetEvent fake{ .peer = static_cast<ENetPeer*>(nullptr) };
+    for (ENetPeer &p : std::span(host->peers, host->peerCount))
+        if (p.state == ENET_PEER_STATE_CONNECTED && static_cast<::peer*>(p.data) == target)
+            { fake.peer = &p; break; }
+
+    if (!fake.peer)
+    {
+        on::ConsoleMessage(event.peer, "`4Failed to locate target peer.``");
+        return;
+    }
+
+    u_short excess = modify_item_inventory(fake, ::slot{item_id, count});
+    if (excess > 0)
+        on::ConsoleMessage(event.peer, std::format("`5Gave {} {}x{} ({} excess).``", target->growid, item_id, count, excess));
+    else
+        on::ConsoleMessage(event.peer, std::format("`5Gave {} {}x{}.``", target->growid, item_id, count));
+}
+
+void setgems(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    auto parts = readch(std::string(text), ' ');
+    if (parts.size() < 3)
+    {
+        on::ConsoleMessage(event.peer, "Usage: /setgems {growid} {amount}");
+        return;
+    }
+
+    std::string target_name = parts[1];
+    int amount = std::atoi(parts[2].c_str());
+
+    ::peer *target = find_peer_by_growid(target_name);
+    if (target)
+    {
+        target->gems = amount;
+        // notify target
+        for (ENetPeer &p : std::span(host->peers, host->peerCount))
+        {
+            if (p.state == ENET_PEER_STATE_CONNECTED && static_cast<::peer*>(p.data) == target)
+            {
+                send_varlist(&p, { "OnSetBux", amount });
+                on::ConsoleMessage(&p, std::format("`5Your gems have been set to {}.``", amount));
+                break;
+            }
+        }
+        on::ConsoleMessage(event.peer, std::format("`5Set {}'s gems to {}.``", target->growid, amount));
+    }
+
+    // also update DB directly
+    ::hStmt hStmt{ "UPDATE peer SET gems = ? WHERE growid = ?" };
+    MYSQL_BIND params[2] = { make_bind_in(amount), make_bind_in(target_name) };
+    mysql_stmt_bind_param(hStmt.pStmt, params);
+    mysql_stmt_execute(hStmt.pStmt);
+}
+
+void ban(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    std::string target_name = get_arg(text);
+    if (target_name.empty())
+    {
+        on::ConsoleMessage(event.peer, "Usage: /ban {growid}");
+        return;
+    }
+
+    // update DB
+    {
+        ::hStmt hStmt{ "UPDATE peer SET banned = 1 WHERE growid = ?" };
+        MYSQL_BIND param = make_bind_in(target_name);
+        mysql_stmt_bind_param(hStmt.pStmt, &param);
+        mysql_stmt_execute(hStmt.pStmt);
+    }
+
+    // kick if online
+    ::peer *target = find_peer_by_growid(target_name);
+    if (target)
+    {
+        target->banned = true;
+        for (ENetPeer &p : std::span(host->peers, host->peerCount))
+        {
+            if (p.state == ENET_PEER_STATE_CONNECTED && static_cast<::peer*>(p.data) == target)
+            {
+                send_action(p, "log", "msg|`4You have been banned.``");
+                enet_peer_disconnect_later(&p, 0);
+                break;
+            }
+        }
+    }
+    on::ConsoleMessage(event.peer, std::format("`5Banned {}.``", target_name));
+}
+
+void unban(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    std::string target_name = get_arg(text);
+    if (target_name.empty())
+    {
+        on::ConsoleMessage(event.peer, "Usage: /unban {growid}");
+        return;
+    }
+
+    ::hStmt hStmt{ "UPDATE peer SET banned = 0 WHERE growid = ?" };
+    MYSQL_BIND param = make_bind_in(target_name);
+    mysql_stmt_bind_param(hStmt.pStmt, &param);
+    mysql_stmt_execute(hStmt.pStmt);
+
+    on::ConsoleMessage(event.peer, std::format("`5Unbanned {}.``", target_name));
+}
+
+void mute(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    std::string target_name = get_arg(text);
+    if (target_name.empty())
+    {
+        on::ConsoleMessage(event.peer, "Usage: /mute {growid}");
+        return;
+    }
+
+    // update DB
+    {
+        ::hStmt hStmt{ "UPDATE peer SET muted = 1 WHERE growid = ?" };
+        MYSQL_BIND param = make_bind_in(target_name);
+        mysql_stmt_bind_param(hStmt.pStmt, &param);
+        mysql_stmt_execute(hStmt.pStmt);
+    }
+
+    // set in-memory if online
+    ::peer *target = find_peer_by_growid(target_name);
+    if (target)
+    {
+        target->muted = true;
+        for (ENetPeer &p : std::span(host->peers, host->peerCount))
+        {
+            if (p.state == ENET_PEER_STATE_CONNECTED && static_cast<::peer*>(p.data) == target)
+            {
+                on::ConsoleMessage(&p, "`4You have been muted.``");
+                break;
+            }
+        }
+    }
+    on::ConsoleMessage(event.peer, std::format("`5Muted {}.``", target_name));
+}
+
+void unmute(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    std::string target_name = get_arg(text);
+    if (target_name.empty())
+    {
+        on::ConsoleMessage(event.peer, "Usage: /unmute {growid}");
+        return;
+    }
+
+    ::hStmt hStmt{ "UPDATE peer SET muted = 0 WHERE growid = ?" };
+    MYSQL_BIND param = make_bind_in(target_name);
+    mysql_stmt_bind_param(hStmt.pStmt, &param);
+    mysql_stmt_execute(hStmt.pStmt);
+
+    ::peer *target = find_peer_by_growid(target_name);
+    if (target) target->muted = false;
+
+    on::ConsoleMessage(event.peer, std::format("`5Unmuted {}.``", target_name));
+}
+
+void kick(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < MODERATOR)
+    {
+        on::ConsoleMessage(event.peer, "`4Permission denied.``");
+        return;
+    }
+
+    std::string target_name = get_arg(text);
+    if (target_name.empty())
+    {
+        on::ConsoleMessage(event.peer, "Usage: /kick {growid}");
+        return;
+    }
+
+    ::peer *target = find_peer_by_growid(target_name);
+    if (!target)
+    {
+        on::ConsoleMessage(event.peer, std::format("`4Player '{}' not found or offline.``", target_name));
+        return;
+    }
+
+    // can't kick higher role unless you're dev
+    if (pPeer->role <= target->role && pPeer->role < DEVELOPER)
+    {
+        on::ConsoleMessage(event.peer, "`4Cannot kick a player with equal or higher role.``");
+        return;
+    }
+
+    for (ENetPeer &p : std::span(host->peers, host->peerCount))
+    {
+        if (p.state == ENET_PEER_STATE_CONNECTED && static_cast<::peer*>(p.data) == target)
+        {
+            on::ConsoleMessage(&p, "`4You have been kicked.``");
+            enet_peer_disconnect_later(&p, 0);
+            break;
+        }
+    }
+    on::ConsoleMessage(event.peer, std::format("`5Kicked {}.``", target_name));
+}
+
+void setrole(ENetEvent& event, const std::string_view text)
+{
+    ::peer *pPeer = static_cast<::peer*>(event.peer->data);
+    if (pPeer->role < DEVELOPER)
+    {
+        on::ConsoleMessage(event.peer, "`4Developer only.``");
+        return;
+    }
+
+    auto parts = readch(std::string(text), ' ');
+    if (parts.size() < 3)
+    {
+        on::ConsoleMessage(event.peer, "Usage: /setrole {growid} {0|1|2}  (0=Player, 1=Mod, 2=Dev)");
+        return;
+    }
+
+    std::string target_name = parts[1];
+    u_char new_role = (u_char)std::atoi(parts[2].c_str());
+    if (new_role > DEVELOPER)
+    {
+        on::ConsoleMessage(event.peer, "`4Invalid role. 0=Player, 1=Mod, 2=Dev``");
+        return;
+    }
+
+    // update DB
+    {
+        ::hStmt hStmt{ "UPDATE peer SET role = ? WHERE growid = ?" };
+        int role_int = new_role;
+        MYSQL_BIND params[2] = { make_bind_in(role_int), make_bind_in(target_name) };
+        mysql_stmt_bind_param(hStmt.pStmt, params);
+        mysql_stmt_execute(hStmt.pStmt);
+    }
+
+    // update online player
+    ::peer *target = find_peer_by_growid(target_name);
+    if (target)
+    {
+        target->role = new_role;
+        target->prefix = (new_role == MODERATOR) ? "#@" : (new_role == DEVELOPER) ? "8@" : "w";
+
+        for (ENetPeer &p : std::span(host->peers, host->peerCount))
+        {
+            if (p.state == ENET_PEER_STATE_CONNECTED && static_cast<::peer*>(p.data) == target)
+            {
+                ENetEvent fake{ .peer = &p };
+                on::NameChanged(fake);
+                on::ConsoleMessage(&p, std::format("`5Your role has been set to {}.``",
+                    new_role == DEVELOPER ? "Developer" : new_role == MODERATOR ? "Moderator" : "Player"));
+                break;
+            }
+        }
+    }
+
+    on::ConsoleMessage(event.peer, std::format("`5Set {}'s role to {}.``", target_name, new_role));
+}

--- a/include/commands/admin.hpp
+++ b/include/commands/admin.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+void give(ENetEvent& event, const std::string_view text);
+void setgems(ENetEvent& event, const std::string_view text);
+void ban(ENetEvent& event, const std::string_view text);
+void unban(ENetEvent& event, const std::string_view text);
+void mute(ENetEvent& event, const std::string_view text);
+void unmute(ENetEvent& event, const std::string_view text);
+void kick(ENetEvent& event, const std::string_view text);
+void setrole(ENetEvent& event, const std::string_view text);

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -21,7 +21,9 @@ void create_table_if_not_exist()
             hair_color INT DEFAULT -1,
             slot_size SMALLINT DEFAULT 16,
             clothing TEXT,
-            inventory TEXT
+            inventory TEXT,
+            banned TINYINT DEFAULT 0,
+            muted TINYINT DEFAULT 0
         );
     )";
 
@@ -51,6 +53,8 @@ void create_table_if_not_exist()
     migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS slot_size SMALLINT DEFAULT 16");
     migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS clothing TEXT");
     migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS inventory TEXT");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS banned TINYINT DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS muted TINYINT DEFAULT 0");
 }
 
 void mysql_connect()

--- a/include/database/database.cpp
+++ b/include/database/database.cpp
@@ -11,22 +11,54 @@ void create_table_if_not_exist()
         CREATE TABLE IF NOT EXISTS peer (
             uid INT AUTO_INCREMENT PRIMARY KEY,
             growid VARCHAR(18) UNIQUE,
-            password VARCHAR(18),
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            password VARCHAR(64),
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            gems INT DEFAULT 0,
+            level SMALLINT UNSIGNED DEFAULT 1,
+            xp SMALLINT UNSIGNED DEFAULT 0,
+            role TINYINT UNSIGNED DEFAULT 0,
+            skin_color INT UNSIGNED DEFAULT 2527912447,
+            hair_color INT DEFAULT -1,
+            slot_size SMALLINT DEFAULT 16,
+            clothing TEXT,
+            inventory TEXT
         );
     )";
-    
-    /* world table */
 
     if (mysql_query(db, query))
     {
         fprintf(stderr, "%s\n", mysql_error(db));
     }
+
+    // migrations for existing tables
+    auto migrate = [](const char *alter_stmt) {
+        if (mysql_query(db, alter_stmt))
+        {
+            if (mysql_errno(db) == 1054) return; // unknown column (fresh table)
+            // 1060 = duplicate column (already migrated), 1064 = syntax (harmless)
+            if (mysql_errno(db) != 1060 && mysql_errno(db) != 1064)
+                fprintf(stderr, "[migrate] %s: %s\n", alter_stmt, mysql_error(db));
+        }
+    };
+
+    migrate("ALTER TABLE peer MODIFY COLUMN password VARCHAR(64)");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS gems INT DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS level SMALLINT UNSIGNED DEFAULT 1");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS xp SMALLINT UNSIGNED DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS role TINYINT UNSIGNED DEFAULT 0");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS skin_color INT UNSIGNED DEFAULT 2527912447");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS hair_color INT DEFAULT -1");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS slot_size SMALLINT DEFAULT 16");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS clothing TEXT");
+    migrate("ALTER TABLE peer ADD COLUMN IF NOT EXISTS inventory TEXT");
 }
 
 void mysql_connect()
 {
     db = mysql_init(NULL);
+
+    my_bool reconnect = 1;
+    mysql_options(db, MYSQL_OPT_RECONNECT, &reconnect);
 
     if (!mysql_real_connect(db, gDatabase_config.host.c_str(), gDatabase_config.user.c_str(), gDatabase_config.password.empty() ? NULL : gDatabase_config.password.c_str(), NULL, gDatabase_config.port, NULL, 0)) 
     {

--- a/include/database/peer.cpp
+++ b/include/database/peer.cpp
@@ -73,10 +73,72 @@ T peer::mysql_select(const std::string &column, const char *arg)
 
 void peer::mysql_select_all()
 {
+    auto trim_null = [](std::string &s) {
+        if (auto pos = s.find('\0'); pos != std::string::npos)
+            s.resize(pos);
+    };
+
     this->user_id    = this->mysql_select<signed>("uid");
     this->growid     = this->mysql_select<std::string>("growid");
     this->password   = this->mysql_select<std::string>("password");
     this->created_at = this->mysql_select<std::time_t>("created_at", "UNIX_TIMESTAMP");
+
+    // gameplay state
+    this->gems        = this->mysql_select<signed>("gems");
+    this->level.front() = (u_short)this->mysql_select<signed>("level");
+    this->level.back()  = (u_short)this->mysql_select<signed>("xp");
+    this->role        = (u_char)this->mysql_select<signed>("role");
+    this->skin_color  = (u_int)this->mysql_select<unsigned>("skin_color");
+    this->hair_color  = this->mysql_select<signed>("hair_color");
+    this->slot_size   = (short)this->mysql_select<signed>("slot_size");
+
+    // clothing CSV: val,val,... (10 floats)
+    std::string cloth_str = this->mysql_select<std::string>("clothing");
+    trim_null(cloth_str);
+    if (!cloth_str.empty())
+    {
+        auto parts = readch(cloth_str, ',');
+        for (std::size_t i = 0; i < std::min(parts.size(), this->clothing.size()); ++i)
+            this->clothing[i] = std::stof(parts[i]);
+    }
+
+    // inventory CSV: id:count,id:count,...
+    std::string inv_str = this->mysql_select<std::string>("inventory");
+    trim_null(inv_str);
+    if (!inv_str.empty())
+    {
+        this->slots.clear();
+        auto pairs = readch(inv_str, ',');
+        for (const auto &pair : pairs)
+        {
+            auto kv = readch(pair, ':');
+            if (kv.size() >= 2)
+                this->slots.emplace_back((short)std::atoi(kv[0].c_str()), (short)std::atoi(kv[1].c_str()));
+        }
+    }
+}
+
+void peer::mysql_save()
+{
+    // clothing → CSV
+    std::string cloth_csv;
+    for (std::size_t i = 0; i < this->clothing.size(); ++i)
+        cloth_csv += (i == 0 ? "" : ",") + std::to_string(this->clothing[i]);
+
+    // inventory → CSV id:count,...
+    std::string inv_csv;
+    for (std::size_t i = 0; i < this->slots.size(); ++i)
+        inv_csv += (i == 0 ? "" : ",") + std::format("{}:{}", this->slots[i].id, this->slots[i].count);
+
+    this->mysql_update<signed>("gems", this->gems);
+    this->mysql_update<signed>("level", this->level.front());
+    this->mysql_update<signed>("xp", this->level.back());
+    this->mysql_update<signed>("role", this->role);
+    this->mysql_update<unsigned>("skin_color", this->skin_color);
+    this->mysql_update<signed>("hair_color", this->hair_color);
+    this->mysql_update<signed>("slot_size", this->slot_size);
+    this->mysql_update<std::string>("clothing", cloth_csv);
+    this->mysql_update<std::string>("inventory", inv_csv);
 }
 
 u_short peer::emplace(::slot slot) 

--- a/include/database/peer.cpp
+++ b/include/database/peer.cpp
@@ -91,6 +91,8 @@ void peer::mysql_select_all()
     this->skin_color  = (u_int)this->mysql_select<unsigned>("skin_color");
     this->hair_color  = this->mysql_select<signed>("hair_color");
     this->slot_size   = (short)this->mysql_select<signed>("slot_size");
+    this->banned      = (bool)this->mysql_select<signed>("banned");
+    this->muted       = (bool)this->mysql_select<signed>("muted");
 
     // clothing CSV: val,val,... (10 floats)
     std::string cloth_str = this->mysql_select<std::string>("clothing");
@@ -139,6 +141,8 @@ void peer::mysql_save()
     this->mysql_update<signed>("slot_size", this->slot_size);
     this->mysql_update<std::string>("clothing", cloth_csv);
     this->mysql_update<std::string>("inventory", inv_csv);
+    this->mysql_update<signed>("banned", this->banned);
+    this->mysql_update<signed>("muted", this->muted);
 }
 
 u_short peer::emplace(::slot slot) 

--- a/include/database/peer.hpp
+++ b/include/database/peer.hpp
@@ -125,6 +125,8 @@ public:
 
     u_short fires_removed{};
     u_short gbc_pity{}; // @note GBC pity; for each 100 will receive super GBC
+    bool banned{};
+    bool muted{};
 };
 
 extern ENetHost* host;

--- a/include/database/peer.hpp
+++ b/include/database/peer.hpp
@@ -70,6 +70,7 @@ public:
     template<typename T>
     T    mysql_select(const std::string &column, const char *arg = "");
     void mysql_select_all();
+    void mysql_save();
 
     int user_id{}; // @note unqiue user id.
     std::string growid{""}, password{""};

--- a/include/https/https.cpp
+++ b/include/https/https.cpp
@@ -138,19 +138,32 @@ void https::listener()
         if (SSL_accept(ssl) > 0)
         {
 
-            char buf[213]; // @note size of growtopia's POST request.
-            const int length{ sizeof(buf) };
+            char buf[1024];
+            std::string request;
+            int total = 0;
 
-            if (SSL_read(ssl, buf, length) == length)
+            // read until \r\n\r\n (end of HTTP headers)
+            while (total < (int)sizeof(buf) - 1)
+            {
+                int n = SSL_read(ssl, buf + total, 1);
+                if (n <= 0) break;
+                total += n;
+                buf[total] = '\0';
+                if (total >= 4 && std::string_view(buf + total - 4, 4) == "\r\n\r\n")
+                    break;
+            }
+            request.assign(buf, total);
+
+            if (!request.empty())
             {
                 puts(buf);
-                
-                if (std::string_view(buf, sizeof(buf )).contains("POST /growtopia/server_data.php HTTP/1.1"))
+
+                if (request.find("POST /growtopia/server_data.php HTTP/1.1") != std::string::npos)
                 {
                     SSL_write(ssl, response.c_str(), response.size());
                 }
             }
-            else ERR_print_errors_fp(stderr); // @note we don't accept growtopia GET. this error is normal if appears.
+            else ERR_print_errors_fp(stderr);
         }
         else ERR_print_errors_fp(stderr);
 


### PR DESCRIPTION
8 role-gated moderation commands: /ban, /unban, /mute, /unmute, /kick, /give, /setgems, /setrole. Permissions: Mod+ for most commands, Dev only for /setrole. Ban check at login, mute check at chat. DB columns auto-migrated.