### PR TITLE
refactor: generate /help from a single emote list

### DIFF
--- a/include/commands/__command.cpp
+++ b/include/commands/__command.cpp
@@ -13,29 +13,51 @@
 #include "ageworld.hpp"
 #include "__command.hpp"
 
+/* emote commands all dispatch to on::Action. listed once here so the
+ * cmd_pool registration and the /help text stay in sync automatically. */
+static constexpr std::array<std::string_view, 24zu> emotes{
+    "wave", "dance", "love", "sleep", "facepalm", "fp",
+    "smh", "yes", "no", "omg", "idk", "shrug",
+    "furious", "rolleyes", "foldarms", "fa", "stubborn", "fold",
+    "dab", "sassy", "dance2", "march", "grumpy", "shy"
+};
+
+/* named commands with their usage hint, shown in /help */
+static constexpr std::string_view named_help =
+    "/find /warp {world} /punch {id} /skin {id} /sb {msg} /who /me {msg} "
+    "/news /weather {id} /ghost /ageworld";
+
 /* if you plan to use this outside of this file, please include in __command.hpp (^-^) - and just make it a void. */
 auto help_return = [](ENetEvent& event, const std::string_view text) 
 {
-    send_action(*event.peer, "log", "msg|>> Commands: /find /warp {world} /punch {id} /skin {id} /sb {msg} /who /me {msg} /news /weather {id} /ghost /ageworld /wave /dance /love /sleep /facepalm /fp /smh /yes /no /omg /idk /shrug /furious /rolleyes /foldarms /stubborn /fold /dab /sassy /dance2 /march /grumpy /shy \0");
+    std::string list{ named_help };
+    for (std::string_view emote : emotes)
+        list += std::format(" /{}", emote);
+
+    send_action(*event.peer, "log", std::format("msg|>> Commands: {} \0", list));
 };
 
-std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::string_view)>> cmd_pool
+std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::string_view)>> cmd_pool = []
 {
-    {"help", help_return },
-    {"?", help_return },
-    {"find", &find},
-    {"warp", &warp},
-    {"punch", &punch},
-    {"skin", &skin},
-    {"sb", &sb},
-    {"who", &who},
-    {"me", &me},
-    {"news", &news},
-    {"weather", &weather},
-    {"ghost", &ghost},
-    {"ageworld", &ageworld},
-    {"wave", &on::Action}, {"dance", &on::Action}, {"love", &on::Action}, {"sleep", &on::Action}, {"facepalm", &on::Action}, {"fp", &on::Action}, 
-    {"smh", &on::Action}, {"yes", &on::Action}, {"no", &on::Action}, {"omg", &on::Action}, {"idk", &on::Action}, {"shrug", &on::Action}, 
-    {"furious", &on::Action}, {"rolleyes", &on::Action}, {"foldarms", &on::Action}, {"fa", &on::Action}, {"stubborn", &on::Action}, {"fold", &on::Action}, 
-    {"dab", &on::Action}, {"sassy", &on::Action}, {"dance2", &on::Action}, {"march", &on::Action}, {"grumpy", &on::Action}, {"shy", &on::Action}
-};
+    std::unordered_map<std::string_view, std::function<void(ENetEvent&, const std::string_view)>> pool
+    {
+        {"help", help_return },
+        {"?", help_return },
+        {"find", &find},
+        {"warp", &warp},
+        {"punch", &punch},
+        {"skin", &skin},
+        {"sb", &sb},
+        {"who", &who},
+        {"me", &me},
+        {"news", &news},
+        {"weather", &weather},
+        {"ghost", &ghost},
+        {"ageworld", &ageworld},
+    };
+
+    for (std::string_view emote : emotes)
+        pool.emplace(emote, &on::Action);
+
+    return pool;
+}();


### PR DESCRIPTION
The emote commands were written twice: once when registering them in `cmd_pool`, and again hardcoded in the `/help` string. Adding a new emote means updating both or they drift out of sync.

- List the 24 emotes once in a `constexpr` array, then build **both** the `cmd_pool` entries and the `/help` text from it.
- Named commands (`/warp {world}`, `/punch {id}`, etc.) keep their manual usage hints since those carry arg info the map keys don't.

While doing this I noticed `/fa` (the foldarms alias) was registered in `cmd_pool` but missing from the old `/help` text — so it now shows up correctly. No other behaviour change. Builds clean on Linux.