### PR TITLE
fix: trim string binds to real column length in mysql_select

### DIFF
--- a/include/database/peer.cpp
+++ b/include/database/peer.cpp
@@ -62,11 +62,20 @@ T peer::mysql_select(const std::string &column, const char *arg)
     MYSQL_BIND param = make_bind_in(this->growid);
     mysql_stmt_bind_param(hStmt.pStmt, &param);
 
+    unsigned long length = 0;
     MYSQL_BIND result = make_bind_out(value);
+    result.length = &length;
     mysql_stmt_bind_result(hStmt.pStmt, &result);
 
     mysql_stmt_execute(hStmt.pStmt);
     mysql_stmt_fetch(hStmt.pStmt);
+
+    // strings bind into a fixed 1024-byte buffer; trim to the real column
+    // length so values compare byte-for-byte (PBKDF2 hashes were failing
+    // verify because the buffer stayed padded with NULs).
+    if constexpr (std::is_same_v<T, std::string>)
+        value.resize(length);
+
     return value;
 }
 /* since we will only select during mysql_select_all */ // @note add templates here if use select outside of this file.


### PR DESCRIPTION
FYI re the hashing being one-sided — root cause isn't in crypt, it's in how the password is read back from the DB.

`mysql_select<std::string>` binds results into a fixed 1024-byte buffer (`make_bind_out(std::string&)` does `buffer.resize(1024)`), but it never set `MYSQL_BIND.length`. So after `mysql_stmt_fetch` the string stays size 1024 — the real ~90-char hash followed by ~934 trailing NULs.

That's why it's one-sided: storing works (the hash lands in the DB fine), but `password_verify` re-derives a clean 44-char hash and bails at:

```cpp
if (computed.size() != hash_b64.size()) return false; // 44 != 1024-ish
```

growid slips through because it's only echoed back, never compared byte-for-byte.

**Fix:** thread `result.length` into `mysql_stmt_fetch` and `resize` the string to the real length. Single spot in `mysql_select`, so every string column reads back correctly — not just password. No new deps.

Builds clean (`make`, exit 0).